### PR TITLE
Add annotation template functions

### DIFF
--- a/charts/platform-system/templates/_helpers.tpl
+++ b/charts/platform-system/templates/_helpers.tpl
@@ -85,4 +85,23 @@ Create the name of the service account to use
 {{- end }}                                                                           
 {{- end }}                                                                           
 
+{{/* Set annotations in subcharts from main chart */}}
+{{/* ex: annotations: {{ include "helper.appAnnotations" ("appAnnotations" .Values.apps.<app>.appAnnotations) | indent 6 }} */}}
+{{- define "helper.appAnnotations" }}
+{{- if .appAnnotations }}
+{{ toYaml .appAnnotations | indent 6 }}
+{{- else }}
+{{- "{}" }}
+{{- end }}
+{{- end }}
+
+{{/* Set annotations in subcharts from main chart */}}
+{{/* ex: annotations: {{ include "helper.saAnnotations" ("saAnnotations" .Values.apps.<app>.serviceAccountAnnotations) }} */}}
+{{- define "helper.saAnnotations" }}
+{{- if .saAnnotations }}
+{{ toYaml .saAnnotations | indent 8 }}
+{{- else }}
+{{- "{}" }}
+{{- end }}
+{{- end }}
 

--- a/charts/platform-system/templates/flux/cert-manager/helm-release-cert-manager.yaml
+++ b/charts/platform-system/templates/flux/cert-manager/helm-release-cert-manager.yaml
@@ -18,13 +18,16 @@ spec:
   interval: {{ .Values.solution.interval }}
   values:
     installCRDs: true
-    nodeSelector: {{ include "helper.nodeSelector" (dict "appNodeSelector" .Values.apps.certManager.nodeSelector "globalNodeSelector" .Values.global.nodeSelector ) | indent 6 }}
-    tolerations: {{ include "helper.tolerations" (dict "appTolerations" .Values.apps.certManager.tolerations "globalTolerations" .Values.global.tolerations ) | indent 6 }}
+    annotations: {{ include "helper.appAnnotations" (dict "appAnnotations" .Values.apps.certManager.annotations) }}
+    nodeSelector: {{ include "helper.nodeSelector" (dict "appNodeSelector" .Values.apps.certManager.nodeSelector "globalNodeSelector" .Values.global.nodeSelector ) }}
+    serviceAccount:
+      annotations: {{ include "helper.saAnnotations" (dict "saAnnotations" .Values.apps.certManager.serviceAccountAnnotations) }}
+    tolerations: {{ include "helper.tolerations" (dict "appTolerations" .Values.apps.certManager.tolerations "globalTolerations" .Values.global.tolerations ) }}
     webhook:
       securePort: {{ .Values.apps.certManager.webhookSecurePort }}
-      nodeSelector: {{ include "helper.nodeSelector" (dict "appNodeSelector" .Values.apps.certManager.nodeSelector "globalNodeSelector" .Values.global.nodeSelector ) | indent 6 }}
-      tolerations: {{ include "helper.tolerations" (dict "appTolerations" .Values.apps.certManager.tolerations "globalTolerations" .Values.global.tolerations ) | indent 6 }}
+      nodeSelector: {{ include "helper.nodeSelector" (dict "appNodeSelector" .Values.apps.certManager.nodeSelector "globalNodeSelector" .Values.global.nodeSelector ) }}
+      tolerations: {{ include "helper.tolerations" (dict "appTolerations" .Values.apps.certManager.tolerations "globalTolerations" .Values.global.tolerations ) }}
     cainjector:
-      nodeSelector: {{ include "helper.nodeSelector" (dict "appNodeSelector" .Values.apps.certManager.nodeSelector "globalNodeSelector" .Values.global.nodeSelector ) | indent 6 }}
-      tolerations: {{ include "helper.tolerations" (dict "appTolerations" .Values.apps.certManager.tolerations "globalTolerations" .Values.global.tolerations ) | indent 6 }}
+      nodeSelector: {{ include "helper.nodeSelector" (dict "appNodeSelector" .Values.apps.certManager.nodeSelector "globalNodeSelector" .Values.global.nodeSelector ) }}
+      tolerations: {{ include "helper.tolerations" (dict "appTolerations" .Values.apps.certManager.tolerations "globalTolerations" .Values.global.tolerations ) }}
 {{ end }}

--- a/charts/platform-system/templates/flux/external-dns/helm-release-external-dns.yaml
+++ b/charts/platform-system/templates/flux/external-dns/helm-release-external-dns.yaml
@@ -5,7 +5,7 @@ metadata:
   name: external-dns
   namespace: flux-system
 spec:
-  releaseName: external-dens
+  releaseName: external-dns
   targetNamespace: {{ .Values.apps.externalDns.namespace }}
   chart:
     spec:
@@ -17,8 +17,9 @@ spec:
         namespace: flux-system
   interval: {{ .Values.solution.interval }}
   values:
-    nodeSelector: {{ include "helper.nodeSelector" (dict "appNodeSelector" .Values.apps.externalDns.nodeSelector "globalNodeSelector" .Values.global.nodeSelector ) | indent 6 }}
-    tolerations: {{ include "helper.tolerations" (dict "appTolerations" .Values.apps.externalDns.tolerations "globalTolerations" .Values.global.tolerations ) | indent 6 }}
+    annotations: {{ include "helper.appAnnotations" (dict "appAnnotations" .Values.apps.externalDns.annotations) }}
+    nodeSelector: {{ include "helper.nodeSelector" (dict "appNodeSelector" .Values.apps.externalDns.nodeSelector "globalNodeSelector" .Values.global.nodeSelector ) }}
+    tolerations: {{ include "helper.tolerations" (dict "appTolerations" .Values.apps.externalDns.tolerations "globalTolerations" .Values.global.tolerations ) }}
     global:
       enabled: false
       name: external-dns
@@ -28,11 +29,13 @@ spec:
       boostrapExpect: 1
     podSecurityContext:
       fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes and AWS token files
+    serviceAccount:
+      annotations: {{ include "helper.saAnnotations" (dict "saAnnotations" .Values.apps.externalDns.serviceAccountAnnotations) }}
     sources:
       - service
       - ingress
-      # - istio-gateway
-      # - istio-virtualservice
+      - istio-gateway
+      - istio-virtualservice
 {{ end }}
 
 

--- a/charts/platform-system/templates/flux/istio/helm-release-istio-base.yaml
+++ b/charts/platform-system/templates/flux/istio/helm-release-istio-base.yaml
@@ -16,6 +16,9 @@ spec:
         namespace: flux-system
   interval: {{ .Values.solution.interval }}
   values:
-    nodeSelector: {{ include "helper.nodeSelector" (dict "appNodeSelector" .Values.apps.istio.nodeSelector "globalNodeSelector" .Values.global.nodeSelector ) | indent 6 }}
-    tolerations: {{ include "helper.tolerations" (dict "appTolerations" .Values.apps.istio.tolerations "globalTolerations" .Values.global.tolerations ) | indent 6 }}
+    annotations: {{ include "helper.appAnnotations" (dict "appAnnotations" .Values.apps.istio.annotations) }}
+    nodeSelector: {{ include "helper.nodeSelector" (dict "appNodeSelector" .Values.apps.istio.nodeSelector "globalNodeSelector" .Values.global.nodeSelector ) }}
+    serviceAccount:
+      annotations: {{ include "helper.saAnnotations" (dict "saAnnotations" .Values.apps.istio.serviceAccountAnnotations) }}
+    tolerations: {{ include "helper.tolerations" (dict "appTolerations" .Values.apps.istio.tolerations "globalTolerations" .Values.global.tolerations ) }}
 {{ end }}

--- a/charts/platform-system/templates/flux/istio/helm-release-istiod.yaml
+++ b/charts/platform-system/templates/flux/istio/helm-release-istiod.yaml
@@ -18,6 +18,9 @@ spec:
         namespace: flux-system
   interval: {{ .Values.solution.interval }}
   values:
-    nodeSelector: {{ include "helper.nodeSelector" (dict "appNodeSelector" .Values.apps.istio.nodeSelector "globalNodeSelector" .Values.global.nodeSelector ) | indent 6 }}
-    tolerations: {{ include "helper.tolerations" (dict "appTolerations" .Values.apps.istio.tolerations "globalTolerations" .Values.global.tolerations ) | indent 6 }}
+    annotations: {{ include "helper.appAnnotations" (dict "appAnnotations" .Values.apps.istio.annotations) }}
+    nodeSelector: {{ include "helper.nodeSelector" (dict "appNodeSelector" .Values.apps.istio.nodeSelector "globalNodeSelector" .Values.global.nodeSelector ) }}
+    serviceAccount:
+      annotations: {{ include "helper.saAnnotations" (dict "saAnnotations" .Values.apps.istio.serviceAccountAnnotations) }}
+    tolerations: {{ include "helper.tolerations" (dict "appTolerations" .Values.apps.istio.tolerations "globalTolerations" .Values.global.tolerations ) }}
 {{ end }}

--- a/charts/platform-system/templates/flux/kyverno-policies/helm-release-kyverno-policies.yaml
+++ b/charts/platform-system/templates/flux/kyverno-policies/helm-release-kyverno-policies.yaml
@@ -19,9 +19,10 @@ spec:
         namespace: flux-system
   interval: {{ .Values.solution.interval }}
   values:
+    annotations: {{ include "helper.appAnnotations" (dict "appAnnotations" .Values.apps.kyverno_policies.annotations) }}
+    nodeSelector: {{ include "helper.nodeSelector" (dict "appNodeSelector" .Values.apps.kyverno_policies.nodeSelector "globalNodeSelector" .Values.global.nodeSelector ) }}
     podSecurityStandard: {{ .Values.apps.kyverno_policies.podSecurityStandard }}
-    nodeSelector: {{ include "helper.nodeSelector" (dict "appNodeSelector" .Values.apps.kyverno.nodeSelector "globalNodeSelector" .Values.global.nodeSelector ) | indent 6 }}
-    tolerations: {{ include "helper.tolerations" (dict "appTolerations" .Values.apps.kyverno.tolerations "globalTolerations" .Values.global.tolerations ) | indent 6 }}
-
-
+    serviceAccount:
+      annotations: {{ include "helper.saAnnotations" (dict "saAnnotations" .Values.apps.kyverno_policies.serviceAccountAnnotations) }}
+    tolerations: {{ include "helper.tolerations" (dict "appTolerations" .Values.apps.kyverno_policies.tolerations "globalTolerations" .Values.global.tolerations ) }}
 {{ end }}

--- a/charts/platform-system/templates/flux/kyverno/helm-release-kyverno.yaml
+++ b/charts/platform-system/templates/flux/kyverno/helm-release-kyverno.yaml
@@ -17,7 +17,10 @@ spec:
         namespace: flux-system
   interval: {{ .Values.solution.interval }}
   values:
-    nodeSelector: {{ include "helper.nodeSelector" (dict "appNodeSelector" .Values.apps.kyverno.nodeSelector "globalNodeSelector" .Values.global.nodeSelector ) | indent 6 }}
-    tolerations: {{ include "helper.tolerations" (dict "appTolerations" .Values.apps.kyverno.tolerations "globalTolerations" .Values.global.tolerations ) | indent 6 }}
+    annotations: {{ include "helper.appAnnotations" (dict "appAnnotations" .Values.apps.kyverno.annotations) }}
+    nodeSelector: {{ include "helper.nodeSelector" (dict "appNodeSelector" .Values.apps.kyverno.nodeSelector "globalNodeSelector" .Values.global.nodeSelector ) }}
+    tolerations: {{ include "helper.tolerations" (dict "appTolerations" .Values.apps.kyverno.tolerations "globalTolerations" .Values.global.tolerations ) }}
+    serviceAccount:
+      annotations: {{ include "helper.saAnnotations" (dict "saAnnotations" .Values.apps.kyverno.serviceAccountAnnotations) }}
 
 {{ end }}

--- a/charts/platform-system/values.yaml
+++ b/charts/platform-system/values.yaml
@@ -9,8 +9,10 @@ prefix: ""
 
 apps:
   istio:
-    enabled: false
+    enabled: true 
     namespace: istio-system
+    annotations: {}
+    serviceAccountAnnotations: {}
     nodeSelector: {}
     tolerations: []
     affinity: {}
@@ -19,6 +21,8 @@ apps:
     namespace: cert-manager
     version: "1.8.2"
     webhookSecurePort: 10260
+    annotations: {}
+    serviceAccountAnnotations: {}
     nodeSelector: {}
     tolerations: []
     affinity: {}
@@ -26,21 +30,27 @@ apps:
     enabled: true
     namespace: external-dns 
     version: "6.7.2"
+    annotations: {}
+    serviceAccountAnnotations: {}
     nodeSelector: {}
     tolerations: []
     affinity: {}
   kyverno:
-    enabled: true
+    enabled: true 
     version: "2.5.1"
     namespace: kyverno
+    annotations: {}
+    serviceAccountAnnotations: {}
     nodeSelector: {}
     tolerations: []
     affinity: {}
   kyverno_policies:
-    enabled: true
+    enabled: true 
     version: "2.5.1"
     namespace: kyverno
     podSecurityStandard: "baseline"
+    annotations:  {}
+    serviceAccountAnnotations: {}
     nodeSelector: {}
     tolerations: []
     affinity: {}


### PR DESCRIPTION
Adds base ability to pass annotations to chart annotations and service account annotations. Useful for IRSA role annotation tagging when kyverno isn't up to enforce the policies Nathan wrote in platform-services charts.