### PR TITLE
Remove wrongly placed istio dir

### DIFF
--- a/charts/platform-system/templates/flux/apps/istio/namespace.yaml
+++ b/charts/platform-system/templates/flux/apps/istio/namespace.yaml
@@ -1,7 +1,0 @@
-{{ if .Values.apps.istio.enabled }}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.apps.istio.namespace }}
-  labels: {{- include "platform-system.labels" . | nindent 4 }}
-{{ end }}


### PR DESCRIPTION
I committed this folder in the wrong place and neglected to remove it. It's existence breaks the chart install so we need to remove it. The correct file is in place in /templates/apps directory.