### PR TITLE
Replacing valuesOverride key with values

### DIFF
--- a/charts/platform-auth/Chart.yaml
+++ b/charts/platform-auth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: platform-auth
 description: Skyfjell Platform Auth Chart
 type: application
-version: 0.1.3
+version: 0.2.0
 dependencies:
   - name: common
     repository: "@skyfjell"

--- a/charts/platform-auth/templates/components/keycloak/helm-release-keycloak.yaml
+++ b/charts/platform-auth/templates/components/keycloak/helm-release-keycloak.yaml
@@ -36,5 +36,5 @@ spec:
   interval: 1h0m0s
   values:
 {{- $defaultValues := ( include "platform-auth.components.keycloak.values" $ | fromYaml ) }}
-{{ ( mergeOverwrite $defaultValues (default dict $parent.valuesOverride )) | toYaml | indent 4 }}
+{{ ( mergeOverwrite $defaultValues (default dict $parent.values )) | toYaml | indent 4 }}
 {{- end }}

--- a/charts/platform-auth/templates/components/keycloak/helm-release-postgres.yaml
+++ b/charts/platform-auth/templates/components/keycloak/helm-release-postgres.yaml
@@ -31,5 +31,5 @@ spec:
   interval: 1h0m0s
   values:
 {{- $defaultValues := ( include "platform-auth.components.keycloak.components.database.values" $ | fromYaml ) }}
-{{ ( mergeOverwrite $defaultValues (default dict $component.valuesOverride )) | toYaml | indent 4 }}
+{{ ( mergeOverwrite $defaultValues (default dict $component.values )) | toYaml | indent 4 }}
 {{- end -}}

--- a/charts/platform-auth/templates/components/proxy/helm-release.yaml
+++ b/charts/platform-auth/templates/components/proxy/helm-release.yaml
@@ -30,5 +30,5 @@ spec:
   interval: 1h0m0s
   values:
 {{- $defaultValues := ( include "platform-auth.app.proxy.template.values" $ | fromYaml ) }}
-{{ ( mergeOverwrite $defaultValues (default dict $component.valuesOverride )) | toYaml | indent 4 }}
+{{ ( mergeOverwrite $defaultValues (default dict $component.values )) | toYaml | indent 4 }}
 {{- end -}}

--- a/charts/platform-auth/values.yaml
+++ b/charts/platform-auth/values.yaml
@@ -64,7 +64,7 @@ components:
             kind: HelmRepository
         nodeSelector: {}
         tolerations: []
-        valuesOverride: {}
+        values: {}
       database:
         # Toggle Component
         # Defaults to postgres instance. Set false and pass auth to keycloak if needed
@@ -89,7 +89,7 @@ components:
           database: keycloak
         nodeSelector: {}
         tolerations: []
-        valuesOverride: {}
+        values: {}
       gateway:
         # selector for istio gateway
         selector: {}
@@ -106,7 +106,7 @@ components:
         # Defaults to `traefik` HelmRepository if not set
         name: ""
         kind: HelmRepository
-    valuesOverride: {}
+    values: {}
     nodeSelector: {}
     tolerations: []
 


### PR DESCRIPTION
Unifying charts we use to pass overrides with simply `values` key. This signals to the end user to treat it just like any other helm chart values.